### PR TITLE
fix: align VolumeLevel type with database schema

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1624,6 +1624,15 @@ components:
         - CUSTOM
       description: Theme preference
 
+    VolumeLevelEnum:
+      type: string
+      enum:
+        - MUTED
+        - LOW
+        - MEDIUM
+        - HIGH
+      description: Volume level preference
+
     # Preference Response Schemas
     UserPreferencesResponse:
       type: object
@@ -1832,8 +1841,7 @@ components:
           type: boolean
           description: Enable system sounds
         volumeLevel:
-          type: boolean
-          description: Enable volume control
+          $ref: "#/components/schemas/VolumeLevelEnum"
         muteNotifications:
           type: boolean
           description: Mute all notifications
@@ -1997,7 +2005,7 @@ components:
         systemSounds:
           type: boolean
         volumeLevel:
-          type: boolean
+          $ref: "#/components/schemas/VolumeLevelEnum"
         muteNotifications:
           type: boolean
 

--- a/internal/dto/preferences.go
+++ b/internal/dto/preferences.go
@@ -105,6 +105,16 @@ const (
 	ThemeCustom Theme = "CUSTOM"
 )
 
+// VolumeLevel represents volume level preference values.
+type VolumeLevel string
+
+const (
+	VolumeLevelMuted  VolumeLevel = "MUTED"
+	VolumeLevelLow    VolumeLevel = "LOW"
+	VolumeLevelMedium VolumeLevel = "MEDIUM"
+	VolumeLevelHigh   VolumeLevel = "HIGH"
+)
+
 // NotificationPreferences represents notification preference settings.
 type NotificationPreferences struct {
 	EmailNotifications    bool      `json:"emailNotifications"`
@@ -177,11 +187,11 @@ type SocialPreferences struct {
 
 // SoundPreferences represents sound preference settings.
 type SoundPreferences struct {
-	NotificationSounds bool      `json:"notificationSounds"`
-	SystemSounds       bool      `json:"systemSounds"`
-	VolumeLevel        bool      `json:"volumeLevel"`
-	MuteNotifications  bool      `json:"muteNotifications"`
-	UpdatedAt          time.Time `json:"updatedAt"`
+	NotificationSounds bool        `json:"notificationSounds"`
+	SystemSounds       bool        `json:"systemSounds"`
+	VolumeLevel        VolumeLevel `json:"volumeLevel"`
+	MuteNotifications  bool        `json:"muteNotifications"`
+	UpdatedAt          time.Time   `json:"updatedAt"`
 }
 
 // ThemePreferences represents theme preference settings.
@@ -258,10 +268,10 @@ type SocialPreferencesUpdate struct {
 
 // SoundPreferencesUpdate represents update request for sound preferences.
 type SoundPreferencesUpdate struct {
-	NotificationSounds *bool `json:"notificationSounds,omitempty"`
-	SystemSounds       *bool `json:"systemSounds,omitempty"`
-	VolumeLevel        *bool `json:"volumeLevel,omitempty"`
-	MuteNotifications  *bool `json:"muteNotifications,omitempty"`
+	NotificationSounds *bool        `json:"notificationSounds,omitempty"`
+	SystemSounds       *bool        `json:"systemSounds,omitempty"`
+	VolumeLevel        *VolumeLevel `json:"volumeLevel,omitempty"`
+	MuteNotifications  *bool        `json:"muteNotifications,omitempty"`
 }
 
 // ThemePreferencesUpdate represents update request for theme preferences.

--- a/internal/repository/preference_repository.go
+++ b/internal/repository/preference_repository.go
@@ -821,7 +821,7 @@ func defaultSoundPreferences() *dto.SoundPreferences {
 	return &dto.SoundPreferences{
 		NotificationSounds: true,
 		SystemSounds:       true,
-		VolumeLevel:        true,
+		VolumeLevel:        dto.VolumeLevelMedium,
 		MuteNotifications:  false,
 		UpdatedAt:          time.Now(),
 	}
@@ -838,7 +838,7 @@ func (r *SQLPreferenceRepository) UpdateSoundPreferences(
 			user_id, notification_sounds, system_sounds, volume_level, mute_notifications, updated_at
 		)
 		VALUES ($1,
-			COALESCE($2, true), COALESCE($3, true), COALESCE($4, true), COALESCE($5, false), NOW()
+			COALESCE($2, true), COALESCE($3, true), COALESCE($4, 'MEDIUM'), COALESCE($5, false), NOW()
 		)
 		ON CONFLICT (user_id) DO UPDATE SET
 			notification_sounds = COALESCE($2, user_sound_preferences.notification_sounds),


### PR DESCRIPTION
## Summary
- Fix type mismatch where `volume_level` in `user_sound_preferences` table uses `VOLUME_LEVEL_ENUM` (MUTED, LOW, MEDIUM, HIGH) but Go code incorrectly used `bool`
- Add `VolumeLevel` enum type to match database schema
- Update DTOs, repository, and OpenAPI documentation

## Test plan
- [x] `make build` - compilation succeeds
- [x] `make test` - all tests pass
- [x] Pre-commit hooks pass (golangci-lint, go-unit-tests, go-build)

## Breaking change
API responses for sound preferences now return `volumeLevel` as a string enum value (`"MUTED"`, `"LOW"`, `"MEDIUM"`, `"HIGH"`) instead of a boolean. Clients consuming this endpoint will need to update their handling.

🤖 Generated with [Claude Code](https://claude.ai/code)